### PR TITLE
Move env_file setting from compose.yaml to compose.override.yaml

### DIFF
--- a/.devcontainer/compose.override.yaml
+++ b/.devcontainer/compose.override.yaml
@@ -1,3 +1,4 @@
 services:
   workspace:
+    # env_file: ../.env
     tty: true

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,6 @@ services:
       - ./firebase:/firebase
 
   workspace:
-    env_file: .env
     environment:
       - FIRESTORE_EMULATOR_HOST=firebase:8080
       - GOOGLE_CLOUD_PROJECT=demo-project


### PR DESCRIPTION
Remove `env_file: .env` from compose.yaml to fix CI failure when .env
does not exist. Leave it commented out in compose.override.yaml so it
can be enabled locally as needed.

https://claude.ai/code/session_019mqWDs41nQMUwMUZSqHxcK