### PR TITLE
Add CI/CD pipeline for Docker build, push, and Cloud Run deployment

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,51 @@
+name: Build, Push and Deploy
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+env:
+  IMAGE: shiori-web
+  REGION: asia-northeast2
+  REPOSITORY: shiori-web
+  SERVICE: shiori-web
+
+jobs:
+  build-push-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: google-github-actions/auth@v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
+
+      - env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          docker build -t ${{ env.REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }} .
+
+      - env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          docker push ${{ env.REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }}
+
+      - env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          gcloud run deploy ${{ env.SERVICE }} \
+            --image ${{ env.REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }} \
+            --region ${{ env.REGION }} \
+            --platform managed


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions workflow that automates the build, push, and deployment process for the Shiori Web application to Google Cloud Run.

## Key Changes
- **New workflow file**: `.github/workflows/docker-push.yml`
  - Triggers on pushes to the `master` branch and manual workflow dispatch
  - Authenticates to Google Cloud using Workload Identity Federation (WIF)
  - Builds a Docker image and pushes it to Google Artifact Registry
  - Deploys the image to Google Cloud Run in the `asia-northeast2` region

## Implementation Details
- Uses GitHub Actions official actions for Google Cloud authentication and SDK setup
- Leverages Workload Identity Federation for secure, keyless authentication to GCP
- Tags Docker images with the commit SHA for traceability
- Configures Docker authentication for the Artifact Registry before pushing
- Deploys to a managed Cloud Run service with the built image
- Requires the following secrets to be configured: `GCP_PROJECT_ID`, `WIF_SERVICE_ACCOUNT`, and `WIF_PROVIDER`

https://claude.ai/code/session_01XrwFc1zQv3rFyvMo8QeLdv