### PR TITLE
Add base path support for multi-tenant routing

### DIFF
--- a/crates/main/src/cookie_jar.rs
+++ b/crates/main/src/cookie_jar.rs
@@ -1,5 +1,6 @@
 use std::convert::Infallible;
 
+use axum::extract::FromRef;
 use axum::extract::FromRequestParts;
 use axum::response::IntoResponse;
 use axum::response::IntoResponseParts;
@@ -11,8 +12,12 @@ use axum_extra::extract::cookie::Key;
 
 use crate::extractor::AuthenticationRequest;
 use crate::extractor::OidcClaims;
+use crate::state::BasePath;
 
-pub(crate) struct CookieJar(SignedCookieJar);
+pub(crate) struct CookieJar {
+    base_path: String,
+    jar: SignedCookieJar,
+}
 
 impl CookieJar {
     const FLOW_COOKIE_NAME: &str = "auth_flow";
@@ -20,26 +25,36 @@ impl CookieJar {
     const SESSION_COOKIE_NAME: &str = "session";
     const STATE_COOKIE_NAME: &str = "oidc_state";
 
+    /// Cookie の `Path` 属性に設定する値を返す。
+    /// `base_path` が空のときは `/`、それ以外は `base_path` そのものを使う。
+    fn cookie_path(&self) -> String {
+        if self.base_path.is_empty() {
+            "/".to_string()
+        } else {
+            self.base_path.clone()
+        }
+    }
+
     pub(crate) fn get_flow(&self) -> Option<String> {
-        self.0
+        self.jar
             .get(Self::FLOW_COOKIE_NAME)
             .map(|c| c.value().to_string())
     }
 
     pub(crate) fn get_nonce(&self) -> Option<String> {
-        self.0
+        self.jar
             .get(Self::NONCE_COOKIE_NAME)
             .map(|c| c.value().to_string())
     }
 
     pub(crate) fn get_session(&self) -> Option<OidcClaims> {
-        self.0
+        self.jar
             .get(Self::SESSION_COOKIE_NAME)
             .and_then(|c| serde_json::from_str::<OidcClaims>(c.value()).ok())
     }
 
     pub(crate) fn get_state(&self) -> Option<String> {
-        self.0
+        self.jar
             .get(Self::STATE_COOKIE_NAME)
             .map(|c| c.value().to_string())
     }
@@ -47,54 +62,61 @@ impl CookieJar {
     pub(crate) fn with_session_cookies(&self, oidc_claims: OidcClaims) -> Self {
         let session_value =
             serde_json::to_string(&oidc_claims).expect("Failed to serialize session claims");
+        let cp = self.cookie_path();
 
         let jar = self
-            .0
+            .jar
             .clone()
-            .remove(Cookie::from(Self::FLOW_COOKIE_NAME))
-            .remove(Cookie::from(Self::STATE_COOKIE_NAME))
-            .remove(Cookie::from(Self::NONCE_COOKIE_NAME))
-            .add(Cookie::build((Self::SESSION_COOKIE_NAME, session_value)).path("/"));
+            .remove(Cookie::build((Self::FLOW_COOKIE_NAME, "")).path(cp.clone()))
+            .remove(Cookie::build((Self::STATE_COOKIE_NAME, "")).path(cp.clone()))
+            .remove(Cookie::build((Self::NONCE_COOKIE_NAME, "")).path(cp.clone()))
+            .add(Cookie::build((Self::SESSION_COOKIE_NAME, session_value)).path(cp));
 
-        Self(jar)
+        Self {
+            base_path: self.base_path.clone(),
+            jar,
+        }
     }
 
     pub(crate) fn with_signin_cookies(&self, auth_request: &AuthenticationRequest) -> Self {
+        let cp = self.cookie_path();
         let jar = self
-            .0
+            .jar
             .clone()
-            .add(Cookie::new(Self::FLOW_COOKIE_NAME, "signin".to_string()))
-            .add(Cookie::new(
-                Self::NONCE_COOKIE_NAME,
-                auth_request.nonce.clone(),
-            ))
-            .add(Cookie::new(
-                Self::STATE_COOKIE_NAME,
-                auth_request.state.clone(),
-            ));
-        Self(jar)
+            .add(Cookie::build((Self::FLOW_COOKIE_NAME, "signin")).path(cp.clone()))
+            .add(
+                Cookie::build((Self::NONCE_COOKIE_NAME, auth_request.nonce.clone()))
+                    .path(cp.clone()),
+            )
+            .add(Cookie::build((Self::STATE_COOKIE_NAME, auth_request.state.clone())).path(cp));
+        Self {
+            base_path: self.base_path.clone(),
+            jar,
+        }
     }
 
     pub(crate) fn with_signup_cookies(&self, auth_request: &AuthenticationRequest) -> Self {
+        let cp = self.cookie_path();
         let jar = self
-            .0
+            .jar
             .clone()
-            .add(Cookie::new(Self::FLOW_COOKIE_NAME, "signup".to_string()))
-            .add(Cookie::new(
-                Self::NONCE_COOKIE_NAME,
-                auth_request.nonce.clone(),
-            ))
-            .add(Cookie::new(
-                Self::STATE_COOKIE_NAME,
-                auth_request.state.clone(),
-            ));
-        Self(jar)
+            .add(Cookie::build((Self::FLOW_COOKIE_NAME, "signup")).path(cp.clone()))
+            .add(
+                Cookie::build((Self::NONCE_COOKIE_NAME, auth_request.nonce.clone()))
+                    .path(cp.clone()),
+            )
+            .add(Cookie::build((Self::STATE_COOKIE_NAME, auth_request.state.clone())).path(cp));
+        Self {
+            base_path: self.base_path.clone(),
+            jar,
+        }
     }
 }
 
 impl<S> FromRequestParts<S> for CookieJar
 where
     Key: axum::extract::FromRef<S>,
+    BasePath: axum::extract::FromRef<S>,
     S: Send + Sync,
 {
     type Rejection = <SignedCookieJar as FromRequestParts<S>>::Rejection;
@@ -103,9 +125,12 @@ where
         parts: &mut axum::http::request::Parts,
         state: &S,
     ) -> Result<Self, Self::Rejection> {
-        SignedCookieJar::from_request_parts(parts, state)
-            .await
-            .map(Self)
+        let jar = SignedCookieJar::from_request_parts(parts, state).await?;
+        let base_path = BasePath::from_ref(state);
+        Ok(Self {
+            base_path: base_path.0,
+            jar,
+        })
     }
 }
 
@@ -113,20 +138,19 @@ impl IntoResponseParts for CookieJar {
     type Error = Infallible;
 
     fn into_response_parts(self, res: ResponseParts) -> Result<ResponseParts, Self::Error> {
-        self.0.into_response_parts(res)
+        self.jar.into_response_parts(res)
     }
 }
 
 impl IntoResponse for CookieJar {
     fn into_response(self) -> Response {
-        self.0.into_response()
+        self.jar.into_response()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use axum_extra::extract::SignedCookieJar;
-    use axum_extra::extract::cookie::Cookie;
     use axum_extra::extract::cookie::Key;
 
     use crate::extractor::AuthenticationRequest;
@@ -136,7 +160,10 @@ mod tests {
 
     fn make_empty_jar() -> CookieJar {
         let key = Key::generate();
-        CookieJar(SignedCookieJar::new(key))
+        CookieJar {
+            base_path: "".to_string(),
+            jar: SignedCookieJar::new(key),
+        }
     }
 
     fn make_auth_request() -> AuthenticationRequest {
@@ -173,8 +200,12 @@ mod tests {
 
     #[test]
     fn test_get_session_returns_none_for_invalid_json() {
+        use axum_extra::extract::cookie::Cookie;
         let key = Key::generate();
-        let jar = CookieJar(SignedCookieJar::new(key).add(Cookie::new("session", "invalid-json")));
+        let jar = CookieJar {
+            base_path: "".to_string(),
+            jar: SignedCookieJar::new(key).add(Cookie::new("session", "invalid-json")),
+        };
         assert!(jar.get_session().is_none());
     }
 
@@ -238,5 +269,63 @@ mod tests {
         assert_eq!(jar.get_flow(), None);
         assert_eq!(jar.get_nonce(), None);
         assert_eq!(jar.get_state(), None);
+    }
+
+    #[test]
+    fn test_with_session_cookies_sets_root_path_when_base_path_is_empty() -> anyhow::Result<()> {
+        let jar = make_empty_jar().with_session_cookies(OidcClaims {
+            sub: "user123".to_string(),
+        });
+        let cookie = jar
+            .jar
+            .get(CookieJar::SESSION_COOKIE_NAME)
+            .ok_or_else(|| anyhow::anyhow!("session cookie not found"))?;
+        assert_eq!(cookie.path(), Some("/"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_with_session_cookies_sets_base_path_when_base_path_is_set() -> anyhow::Result<()> {
+        let key = Key::generate();
+        let jar = CookieJar {
+            base_path: "/app".to_string(),
+            jar: SignedCookieJar::new(key),
+        };
+        let jar = jar.with_session_cookies(OidcClaims {
+            sub: "user123".to_string(),
+        });
+        let cookie = jar
+            .jar
+            .get(CookieJar::SESSION_COOKIE_NAME)
+            .ok_or_else(|| anyhow::anyhow!("session cookie not found"))?;
+        assert_eq!(cookie.path(), Some("/app"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_with_signin_cookies_sets_root_path_when_base_path_is_empty() -> anyhow::Result<()> {
+        let jar = make_empty_jar().with_signin_cookies(&make_auth_request());
+        let cookie = jar
+            .jar
+            .get(CookieJar::FLOW_COOKIE_NAME)
+            .ok_or_else(|| anyhow::anyhow!("auth_flow cookie not found"))?;
+        assert_eq!(cookie.path(), Some("/"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_with_signin_cookies_sets_base_path_when_base_path_is_set() -> anyhow::Result<()> {
+        let key = Key::generate();
+        let jar = CookieJar {
+            base_path: "/app".to_string(),
+            jar: SignedCookieJar::new(key),
+        };
+        let jar = jar.with_signin_cookies(&make_auth_request());
+        let cookie = jar
+            .jar
+            .get(CookieJar::FLOW_COOKIE_NAME)
+            .ok_or_else(|| anyhow::anyhow!("auth_flow cookie not found"))?;
+        assert_eq!(cookie.path(), Some("/app"));
+        Ok(())
     }
 }

--- a/crates/main/src/env.rs
+++ b/crates/main/src/env.rs
@@ -2,6 +2,8 @@ use anyhow::Context as _;
 
 /// アプリケーション全体で使用する環境変数。
 pub(crate) struct Env {
+    /// アプリケーションのベースパス (例: `/app`、デフォルト: `""`)
+    pub base_path: String,
     /// OIDC の client id
     pub oidc_client_id: String,
     /// OIDC の client secret
@@ -19,6 +21,7 @@ impl Env {
         }
 
         Ok(Self {
+            base_path: std::env::var("BASE_PATH").unwrap_or_default(),
             oidc_client_id: read_var("OIDC_CLIENT_ID")?,
             oidc_client_secret: read_var("OIDC_CLIENT_SECRET")?,
             oidc_issuer_url: read_var("OIDC_ISSUER_URL")?,
@@ -35,6 +38,7 @@ mod tests {
     fn from_env_reads_all_variables() -> anyhow::Result<()> {
         temp_env::with_vars(
             [
+                ("BASE_PATH", Some("/app")),
                 ("OIDC_CLIENT_ID", Some("test_client_id")),
                 ("OIDC_CLIENT_SECRET", Some("test_client_secret")),
                 ("OIDC_ISSUER_URL", Some("https://issuer.example.com")),
@@ -45,6 +49,7 @@ mod tests {
             ],
             || {
                 let env = Env::from_env()?;
+                assert_eq!(env.base_path, "/app");
                 assert_eq!(env.oidc_client_id, "test_client_id");
                 assert_eq!(env.oidc_client_secret, "test_client_secret");
                 assert_eq!(env.oidc_issuer_url, "https://issuer.example.com");
@@ -55,9 +60,31 @@ mod tests {
     }
 
     #[test]
+    fn from_env_base_path_defaults_to_empty() -> anyhow::Result<()> {
+        temp_env::with_vars(
+            [
+                ("BASE_PATH", None::<&str>),
+                ("OIDC_CLIENT_ID", Some("test_client_id")),
+                ("OIDC_CLIENT_SECRET", Some("test_client_secret")),
+                ("OIDC_ISSUER_URL", Some("https://issuer.example.com")),
+                (
+                    "OIDC_REDIRECT_URI",
+                    Some("http://localhost:3000/auth/callback"),
+                ),
+            ],
+            || {
+                let env = Env::from_env()?;
+                assert_eq!(env.base_path, "");
+                Ok(())
+            },
+        )
+    }
+
+    #[test]
     fn from_env_fails_when_variable_is_missing() -> anyhow::Result<()> {
         temp_env::with_vars(
             [
+                ("BASE_PATH", None::<&str>),
                 ("OIDC_CLIENT_ID", None::<&str>),
                 ("OIDC_CLIENT_SECRET", Some("secret")),
                 ("OIDC_ISSUER_URL", Some("https://issuer.example.com")),

--- a/crates/main/src/extractor.rs
+++ b/crates/main/src/extractor.rs
@@ -11,11 +11,13 @@ use axum::http::StatusCode;
 use axum_extra::extract::cookie::Key;
 
 use crate::CookieJar;
+use crate::state::BasePath;
 
 pub(crate) struct RequireAuth(pub OidcClaims);
 
 impl<S> FromRequestParts<S> for RequireAuth
 where
+    BasePath: axum::extract::FromRef<S>,
     Key: axum::extract::FromRef<S>,
     S: Send + Sync,
 {
@@ -43,6 +45,7 @@ where
 
 impl<S> OptionalFromRequestParts<S> for RequireAuth
 where
+    BasePath: axum::extract::FromRef<S>,
     Key: axum::extract::FromRef<S>,
     S: Send + Sync,
 {

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
     let state = AppState::from_env(&env).await?;
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
     tracing::info!("listening on 0.0.0.0:3000");
-    axum::serve(listener, router::router().with_state(state)).await?;
+    axum::serve(listener, router::router(&env.base_path).with_state(state)).await?;
     Ok(())
 }
 
@@ -82,8 +82,12 @@ mod tests {
     }
 
     fn test_app(sub: impl Into<String>) -> anyhow::Result<axum::Router> {
-        let state = AppState::new(Arc::new(MockOidcClient::new(sub)), firestore_user_repo()?);
-        Ok(crate::router::router().with_state(state))
+        let state = AppState::new(
+            "".to_string(),
+            Arc::new(MockOidcClient::new(sub)),
+            firestore_user_repo()?,
+        );
+        Ok(crate::router::router("").with_state(state))
     }
 
     #[tokio::test]
@@ -172,11 +176,15 @@ mod tests {
     #[serial_test::serial]
     async fn signup_callback_creates_user_and_sets_session() -> anyhow::Result<()> {
         let sub = unique_user_id();
-        let state = AppState::new(Arc::new(MockOidcClient::new(&sub)), firestore_user_repo()?);
+        let state = AppState::new(
+            "".to_string(),
+            Arc::new(MockOidcClient::new(&sub)),
+            firestore_user_repo()?,
+        );
 
         // Step 1: Signup to get CSRF and nonce cookies
         let signup_response = send_request(
-            crate::router::router().with_state(state.clone()),
+            crate::router::router("").with_state(state.clone()),
             axum::http::Request::builder()
                 .uri("/auth/signup")
                 .body(axum::body::Body::empty())?,
@@ -186,7 +194,7 @@ mod tests {
 
         // Step 2: Call callback with code, state, and cookies
         let response = send_request(
-            crate::router::router().with_state(state),
+            crate::router::router("").with_state(state),
             axum::http::Request::builder()
                 .uri("/auth/callback?code=test_code&state=test_state")
                 .header(axum::http::header::COOKIE, &cookie_header)
@@ -224,11 +232,15 @@ mod tests {
         user_repo
             .store(User::create(sub.parse::<crate::model::GoogleUserId>()?))
             .await?;
-        let state = AppState::new(Arc::new(MockOidcClient::new(&sub)), user_repo);
+        let state = AppState::new(
+            "".to_string(),
+            Arc::new(MockOidcClient::new(&sub)),
+            user_repo,
+        );
 
         // Step 1: Signin
         let signin_response = send_request(
-            crate::router::router().with_state(state.clone()),
+            crate::router::router("").with_state(state.clone()),
             axum::http::Request::builder()
                 .uri("/auth/signin")
                 .body(axum::body::Body::empty())?,
@@ -238,7 +250,7 @@ mod tests {
 
         // Step 2: Callback
         let response = send_request(
-            crate::router::router().with_state(state),
+            crate::router::router("").with_state(state),
             axum::http::Request::builder()
                 .uri("/auth/callback?code=test_code&state=test_state")
                 .header(axum::http::header::COOKIE, &cookie_header)
@@ -256,11 +268,15 @@ mod tests {
     #[serial_test::serial]
     async fn signin_callback_with_unknown_user_returns_error() -> anyhow::Result<()> {
         let sub = unique_user_id();
-        let state = AppState::new(Arc::new(MockOidcClient::new(&sub)), firestore_user_repo()?);
+        let state = AppState::new(
+            "".to_string(),
+            Arc::new(MockOidcClient::new(&sub)),
+            firestore_user_repo()?,
+        );
 
         // Step 1: Signin (no user in DB)
         let signin_response = send_request(
-            crate::router::router().with_state(state.clone()),
+            crate::router::router("").with_state(state.clone()),
             axum::http::Request::builder()
                 .uri("/auth/signin")
                 .body(axum::body::Body::empty())?,
@@ -270,7 +286,7 @@ mod tests {
 
         // Step 2: Callback — should fail because user doesn't exist
         let response = send_request(
-            crate::router::router().with_state(state),
+            crate::router::router("").with_state(state),
             axum::http::Request::builder()
                 .uri("/auth/callback?code=test_code&state=test_state")
                 .header(axum::http::header::COOKIE, &cookie_header)
@@ -309,11 +325,15 @@ mod tests {
     async fn get_root_with_session_returns_ok() -> anyhow::Result<()> {
         // Full flow: signup → callback → access root
         let sub = unique_user_id();
-        let state = AppState::new(Arc::new(MockOidcClient::new(&sub)), firestore_user_repo()?);
+        let state = AppState::new(
+            "".to_string(),
+            Arc::new(MockOidcClient::new(&sub)),
+            firestore_user_repo()?,
+        );
 
         // Step 1: Signup
         let signup_response = send_request(
-            crate::router::router().with_state(state.clone()),
+            crate::router::router("").with_state(state.clone()),
             axum::http::Request::builder()
                 .uri("/auth/signup")
                 .body(axum::body::Body::empty())?,
@@ -323,7 +343,7 @@ mod tests {
 
         // Step 2: Callback
         let callback_response = send_request(
-            crate::router::router().with_state(state.clone()),
+            crate::router::router("").with_state(state.clone()),
             axum::http::Request::builder()
                 .uri("/auth/callback?code=test_code&state=test_state")
                 .header(axum::http::header::COOKIE, &signup_cookie_header)
@@ -334,7 +354,7 @@ mod tests {
 
         // Step 3: Access root with session cookie
         let response = send_request(
-            crate::router::router().with_state(state),
+            crate::router::router("").with_state(state),
             axum::http::Request::builder()
                 .uri("/")
                 .header(axum::http::header::COOKIE, &session_cookie_header)
@@ -346,6 +366,165 @@ mod tests {
         assert!(
             body.starts_with("OK: "),
             "Expected body to start with 'OK: ', got: {body}"
+        );
+        Ok(())
+    }
+
+    // --- BASE_PATH tests ---
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn with_base_path_routes_are_under_base_path() -> anyhow::Result<()> {
+        let base_path = "/app";
+        let state = AppState::new(
+            base_path.to_string(),
+            Arc::new(MockOidcClient::new("base_path_route_user")),
+            firestore_user_repo()?,
+        );
+
+        // Route exists under base path
+        let response = send_request(
+            crate::router::router(base_path).with_state(state.clone()),
+            axum::http::Request::builder()
+                .uri("/app/auth/signup")
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::TEMPORARY_REDIRECT,
+            "Expected route under base path to exist"
+        );
+
+        // Route does NOT exist without base path
+        let response = send_request(
+            crate::router::router(base_path).with_state(state),
+            axum::http::Request::builder()
+                .uri("/auth/signup")
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::NOT_FOUND,
+            "Expected route without base path to return 404"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn with_base_path_callback_redirects_to_base_path() -> anyhow::Result<()> {
+        let base_path = "/app";
+        let sub = unique_user_id();
+        let state = AppState::new(
+            base_path.to_string(),
+            Arc::new(MockOidcClient::new(&sub)),
+            firestore_user_repo()?,
+        );
+
+        // Step 1: Signup
+        let signup_response = send_request(
+            crate::router::router(base_path).with_state(state.clone()),
+            axum::http::Request::builder()
+                .uri("/app/auth/signup")
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        let cookie_header = extract_cookies(&signup_response);
+
+        // Step 2: Callback — redirect target should be base_path
+        let response = send_request(
+            crate::router::router(base_path).with_state(state),
+            axum::http::Request::builder()
+                .uri("/app/auth/callback?code=test_code&state=test_state")
+                .header(axum::http::header::COOKIE, &cookie_header)
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::TEMPORARY_REDIRECT
+        );
+        let location = response
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .expect("Expected location header")
+            .to_str()?;
+        assert_eq!(location, "/app");
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn with_base_path_session_cookie_has_base_path() -> anyhow::Result<()> {
+        let base_path = "/app";
+        let sub = unique_user_id();
+        let state = AppState::new(
+            base_path.to_string(),
+            Arc::new(MockOidcClient::new(&sub)),
+            firestore_user_repo()?,
+        );
+
+        // Step 1: Signup
+        let signup_response = send_request(
+            crate::router::router(base_path).with_state(state.clone()),
+            axum::http::Request::builder()
+                .uri("/app/auth/signup")
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        let cookie_header = extract_cookies(&signup_response);
+
+        // Step 2: Callback — session cookie Path should be base_path
+        let response = send_request(
+            crate::router::router(base_path).with_state(state),
+            axum::http::Request::builder()
+                .uri("/app/auth/callback?code=test_code&state=test_state")
+                .header(axum::http::header::COOKIE, &cookie_header)
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        let set_cookies: Vec<_> = response
+            .headers()
+            .get_all(axum::http::header::SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok().map(|s| s.to_string()))
+            .collect();
+        assert!(
+            set_cookies
+                .iter()
+                .any(|c| c.contains("session") && c.contains("Path=/app")),
+            "Expected session cookie with Path=/app, got: {set_cookies:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn with_base_path_root_contains_base_path_links() -> anyhow::Result<()> {
+        let base_path = "/app";
+        let state = AppState::new(
+            base_path.to_string(),
+            Arc::new(MockOidcClient::new("base_path_links_user")),
+            firestore_user_repo()?,
+        );
+        let response = send_request(
+            crate::router::router(base_path).with_state(state),
+            axum::http::Request::builder()
+                .uri("/app")
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let body = response.into_body_string().await?;
+        assert!(
+            body.contains("/app/auth/signup"),
+            "Expected landing page to contain /app/auth/signup link, got: {body}"
+        );
+        assert!(
+            body.contains("/app/auth/signin"),
+            "Expected landing page to contain /app/auth/signin link, got: {body}"
         );
         Ok(())
     }

--- a/crates/main/src/router.rs
+++ b/crates/main/src/router.rs
@@ -5,6 +5,11 @@ use axum::Router;
 
 use crate::AppState;
 
-pub(crate) fn router() -> Router<AppState> {
-    Router::new().merge(auth::router()).merge(root::router())
+pub(crate) fn router(base_path: &str) -> Router<AppState> {
+    let inner = Router::new().merge(auth::router()).merge(root::router());
+    if base_path.is_empty() {
+        inner
+    } else {
+        Router::new().nest(base_path, inner)
+    }
 }

--- a/crates/main/src/router/auth/callback.rs
+++ b/crates/main/src/router/auth/callback.rs
@@ -107,5 +107,10 @@ async fn handler(
     tracing::info!(sub = %oidc_claims.sub, "auth callback: authentication successful, setting session cookie");
     let jar = jar.with_session_cookies(oidc_claims);
 
-    Ok((jar, Redirect::temporary("/")))
+    let redirect_target = if app_state.base_path.is_empty() {
+        "/".to_string()
+    } else {
+        app_state.base_path.clone()
+    };
+    Ok((jar, Redirect::temporary(&redirect_target)))
 }

--- a/crates/main/src/router/root.rs
+++ b/crates/main/src/router/root.rs
@@ -1,4 +1,5 @@
 use axum::Router;
+use axum::extract::State;
 use axum::response::Html;
 use axum::response::IntoResponse;
 use axum::routing::get;
@@ -10,21 +11,23 @@ pub(crate) fn router() -> Router<AppState> {
     Router::new().route("/", get(handler))
 }
 
-async fn handler(auth: Option<RequireAuth>) -> impl IntoResponse {
+async fn handler(State(state): State<AppState>, auth: Option<RequireAuth>) -> impl IntoResponse {
     match auth {
         Some(RequireAuth(claims)) => Html(format!("OK: {}", claims.sub)).into_response(),
-        None => Html(
-            r#"<!DOCTYPE html>
+        None => {
+            let base = &state.base_path;
+            Html(format!(
+                r#"<!DOCTYPE html>
 <html>
 <head><title>shiori</title></head>
 <body>
 <h1>shiori</h1>
-<p><a href="/auth/signup">Sign Up</a></p>
-<p><a href="/auth/signin">Sign In</a></p>
+<p><a href="{base}/auth/signup">Sign Up</a></p>
+<p><a href="{base}/auth/signin">Sign In</a></p>
 </body>
 </html>"#
-                .to_string(),
-        )
-        .into_response(),
+            ))
+            .into_response()
+        }
     }
 }

--- a/crates/main/src/state.rs
+++ b/crates/main/src/state.rs
@@ -6,16 +6,27 @@ use crate::extractor::OidcClient;
 use crate::extractor::real_oidc_client;
 use crate::model::UserRepository;
 
+/// `AppState` から取り出したベースパス。`CookieJar` の抽出時に使用する。
+#[derive(Clone)]
+pub(crate) struct BasePath(pub String);
+
 #[derive(Clone)]
 pub(crate) struct AppState {
+    /// アプリケーションのベースパス (例: `/app`、空文字はルート)
+    pub base_path: String,
     pub cookie_key: Key,
     pub oidc_client: Arc<dyn OidcClient>,
     pub user_repository: Arc<dyn UserRepository>,
 }
 
 impl AppState {
-    pub fn new(oidc_client: Arc<dyn OidcClient>, user_repository: Arc<dyn UserRepository>) -> Self {
+    pub fn new(
+        base_path: String,
+        oidc_client: Arc<dyn OidcClient>,
+        user_repository: Arc<dyn UserRepository>,
+    ) -> Self {
         Self {
+            base_path,
             cookie_key: Key::generate(),
             oidc_client,
             user_repository,
@@ -34,7 +45,17 @@ impl AppState {
             bouzuya_firestore_client::FirestoreOptions::default(),
         )?;
         let user_repository = Arc::new(crate::model::FirestoreUserRepository::new(firestore));
-        Ok(Self::new(Arc::new(oidc_client), user_repository))
+        Ok(Self::new(
+            env.base_path.clone(),
+            Arc::new(oidc_client),
+            user_repository,
+        ))
+    }
+}
+
+impl axum::extract::FromRef<AppState> for BasePath {
+    fn from_ref(state: &AppState) -> Self {
+        BasePath(state.base_path.clone())
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds support for configuring an optional base path for the application, enabling it to be served under a sub-path (e.g., `/app`) rather than at the root. This is useful for multi-tenant deployments or when the application is behind a reverse proxy that routes to a specific path.

## Key Changes

- **Environment Configuration**: Added `BASE_PATH` environment variable (defaults to empty string) in `env.rs`

- **Router Nesting**: Modified `router()` function to accept a `base_path` parameter and conditionally nest all routes under that path using `Router::nest()` when base_path is non-empty

- **State Management**: 
  - Updated `AppState` to store the `base_path` field
  - Added `BasePath` extractor struct to make base_path available to handlers via `FromRef`
  - Updated `AppState::new()` to accept base_path as first parameter

- **Cookie Path Handling**: Enhanced `CookieJar` to:
  - Store the base_path internally
  - Set cookie `Path` attribute to base_path (or "/" when base_path is empty)
  - Apply correct path to all cookie operations (signin, signup, session cookies)
  - Updated `FromRequestParts` implementation to extract BasePath from state

- **Redirect Targets**: Modified auth callback handler to redirect to base_path instead of always redirecting to "/"

- **HTML Links**: Updated root handler to generate links with base_path prefix (e.g., `/app/auth/signup` instead of `/auth/signup`)

- **Comprehensive Tests**: Added 4 new integration tests validating:
  - Routes are accessible under base_path and return 404 without it
  - Callback redirects to base_path
  - Session cookies have correct Path attribute
  - Landing page links include base_path

## Implementation Details

- When `base_path` is empty, the application behaves exactly as before (routes at root, cookies use "/" path)
- When `base_path` is set, all routes are nested under that path and cookies are scoped to that path
- The base_path is passed through the dependency injection system via `AppState` and extracted where needed
- All existing tests updated to pass empty string for base_path to maintain backward compatibility

https://claude.ai/code/session_01D8HiDP8xyuhB25gqbbi6Bf