### PR TITLE
Add signout endpoint with session cookie clearing

### DIFF
--- a/crates/main/src/cookie_jar.rs
+++ b/crates/main/src/cookie_jar.rs
@@ -76,6 +76,18 @@ impl CookieJar {
         }
     }
 
+    pub(crate) fn with_signout_cookies(&self) -> Self {
+        let cp = self.cookie_path();
+        let jar = self
+            .jar
+            .clone()
+            .remove(Cookie::build((Self::SESSION_COOKIE_NAME, "")).path(cp));
+        Self {
+            base_path: self.base_path.clone(),
+            jar,
+        }
+    }
+
     pub(crate) fn with_signin_cookies(&self, auth_request: &AuthenticationRequest) -> Self {
         let cp = self.cookie_path();
         let jar = self
@@ -256,6 +268,16 @@ mod tests {
         assert_eq!(jar.get_flow(), None);
         assert_eq!(jar.get_nonce(), None);
         assert_eq!(jar.get_state(), None);
+    }
+
+    #[test]
+    fn test_with_signout_cookies_removes_session() {
+        let user_id_str = make_session();
+        let jar = make_empty_jar()
+            .with_signin_cookies(&make_auth_request())
+            .with_session_cookies(user_id_str)
+            .with_signout_cookies();
+        assert!(jar.get_session().is_none());
     }
 
     #[test]

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -66,6 +66,47 @@ mod tests {
         }
     }
 
+    struct MockUserRepository {
+        users: std::sync::Mutex<Vec<crate::model::User>>,
+    }
+
+    impl MockUserRepository {
+        fn new() -> Self {
+            Self {
+                users: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl UserRepository for MockUserRepository {
+        async fn find(
+            &self,
+            id: &crate::model::UserId,
+        ) -> anyhow::Result<Option<crate::model::User>> {
+            let users = self.users.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok(users.iter().find(|u| u.id() == *id).cloned())
+        }
+
+        async fn find_by_google_user_id(
+            &self,
+            id: &crate::model::GoogleUserId,
+        ) -> anyhow::Result<Option<crate::model::User>> {
+            let users = self.users.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok(users.iter().find(|u| u.google_user_id() == id).cloned())
+        }
+
+        async fn store(&self, user: crate::model::User) -> anyhow::Result<()> {
+            let mut users = self.users.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+            if let Some(pos) = users.iter().position(|u| u.id() == user.id()) {
+                users[pos] = user;
+            } else {
+                users.push(user);
+            }
+            Ok(())
+        }
+    }
+
     const TEST_COOKIE_SIGNING_SECRET: &str =
         "test_cookie_signing_secret_that_is_at_least_64_bytes_long_padding";
 
@@ -92,6 +133,16 @@ mod tests {
             firestore_user_repo()?,
         );
         Ok(crate::router::router("").with_state(state))
+    }
+
+    fn test_app_with_mock_repo(sub: impl Into<String>) -> axum::Router {
+        let state = AppState::new(
+            "".to_string(),
+            TEST_COOKIE_SIGNING_SECRET,
+            Arc::new(MockOidcClient::new(sub)),
+            Arc::new(MockUserRepository::new()),
+        );
+        crate::router::router("").with_state(state)
     }
 
     #[tokio::test]
@@ -508,6 +559,117 @@ mod tests {
                 .any(|c| c.contains("session") && c.contains("Path=/app")),
             "Expected session cookie with Path=/app, got: {set_cookies:?}"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_auth_signout_redirects_to_root() -> anyhow::Result<()> {
+        let response = send_request(
+            test_app_with_mock_repo("test_signout_redirect_user"),
+            axum::http::Request::builder()
+                .method(axum::http::Method::GET)
+                .uri("/auth/signout")
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::TEMPORARY_REDIRECT
+        );
+        let location = response
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .expect("Expected location header")
+            .to_str()?;
+        assert_eq!(location, "/");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_auth_signout_clears_session_cookie() -> anyhow::Result<()> {
+        let sub = unique_user_id();
+        let state = AppState::new(
+            "".to_string(),
+            TEST_COOKIE_SIGNING_SECRET,
+            Arc::new(MockOidcClient::new(&sub)),
+            Arc::new(MockUserRepository::new()),
+        );
+
+        // Step 1: Signup
+        let signup_response = send_request(
+            crate::router::router("").with_state(state.clone()),
+            axum::http::Request::builder()
+                .uri("/auth/signup")
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        let signup_cookie_header = extract_cookies(&signup_response);
+
+        // Step 2: Callback
+        let callback_response = send_request(
+            crate::router::router("").with_state(state.clone()),
+            axum::http::Request::builder()
+                .uri("/auth/callback?code=test_code&state=test_state")
+                .header(axum::http::header::COOKIE, &signup_cookie_header)
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        let session_cookie_header = extract_cookies(&callback_response);
+
+        // Step 3: Signout
+        let response = send_request(
+            crate::router::router("").with_state(state),
+            axum::http::Request::builder()
+                .uri("/auth/signout")
+                .header(axum::http::header::COOKIE, &session_cookie_header)
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::TEMPORARY_REDIRECT
+        );
+        let set_cookies: Vec<_> = response
+            .headers()
+            .get_all(axum::http::header::SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok().map(|s| s.to_string()))
+            .collect();
+        assert!(
+            set_cookies
+                .iter()
+                .any(|c| c.contains("session") && c.contains("Max-Age=0")),
+            "Expected session cookie to be cleared, got: {set_cookies:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn with_base_path_signout_redirects_to_base_path() -> anyhow::Result<()> {
+        let base_path = "/app";
+        let state = AppState::new(
+            base_path.to_string(),
+            TEST_COOKIE_SIGNING_SECRET,
+            Arc::new(MockOidcClient::new("signout_base_path_user")),
+            Arc::new(MockUserRepository::new()),
+        );
+        let response = send_request(
+            crate::router::router(base_path).with_state(state),
+            axum::http::Request::builder()
+                .uri("/app/auth/signout")
+                .body(axum::body::Body::empty())?,
+        )
+        .await?;
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::TEMPORARY_REDIRECT
+        );
+        let location = response
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .expect("Expected location header")
+            .to_str()?;
+        assert_eq!(location, "/app");
         Ok(())
     }
 

--- a/crates/main/src/router/auth.rs
+++ b/crates/main/src/router/auth.rs
@@ -1,5 +1,6 @@
 mod callback;
 mod signin;
+mod signout;
 mod signup;
 
 use axum::Router;
@@ -10,5 +11,6 @@ pub(crate) fn router() -> Router<AppState> {
     Router::new()
         .merge(callback::router())
         .merge(signin::router())
+        .merge(signout::router())
         .merge(signup::router())
 }

--- a/crates/main/src/router/auth/signout.rs
+++ b/crates/main/src/router/auth/signout.rs
@@ -1,0 +1,23 @@
+use axum::Router;
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::response::Redirect;
+use axum::routing::get;
+
+use crate::AppState;
+use crate::CookieJar;
+
+pub(crate) fn router() -> Router<AppState> {
+    Router::new().route("/auth/signout", get(handler))
+}
+
+async fn handler(State(state): State<AppState>, jar: CookieJar) -> impl IntoResponse {
+    tracing::info!("auth signout: removing session cookie");
+    let jar = jar.with_signout_cookies();
+    let redirect_target = if state.base_path.is_empty() {
+        "/".to_string()
+    } else {
+        state.base_path.clone()
+    };
+    (jar, Redirect::temporary(&redirect_target))
+}


### PR DESCRIPTION
## Summary
This PR implements a complete signout flow for the authentication system, allowing users to clear their session and be redirected to the home page.

## Key Changes
- **New signout endpoint** (`/auth/signout`): Added a GET endpoint that clears the session cookie and redirects users to the root path (or base path if configured)
- **Cookie jar signout support**: Implemented `with_signout_cookies()` method to properly remove the session cookie with appropriate expiration
- **Mock repository for testing**: Added `MockUserRepository` struct to support testing without a real database backend
- **Comprehensive test coverage**: Added three new tests covering:
  - Basic signout redirect behavior
  - Session cookie clearing during signout
  - Base path handling in signout redirects

## Implementation Details
- The signout handler uses the existing `CookieJar` abstraction to manage cookie removal
- Session cookies are cleared by setting `Max-Age=0` on the cookie
- The redirect target respects the configured base path, redirecting to `/` for root deployments or `/{base_path}` for subpath deployments
- The `MockUserRepository` implements the full `UserRepository` trait with in-memory storage using `Mutex<Vec<User>>` for thread-safe test state management

https://claude.ai/code/session_01LfYnhRxsuinPUPLUo6h363